### PR TITLE
handle the null case

### DIFF
--- a/lib/el_tooltip.dart
+++ b/lib/el_tooltip.dart
@@ -131,7 +131,7 @@ class _ElTooltipState extends State<ElTooltip> with WidgetsBindingObserver {
     );
 
     if (_overlayEntryHidden != null) {
-      overlayStateHidden.insert(_overlayEntryHidden!);
+      overlayStateHidden?.insert(_overlayEntryHidden!);
     }
   }
 
@@ -225,7 +225,7 @@ class _ElTooltipState extends State<ElTooltip> with WidgetsBindingObserver {
     );
 
     if (_overlayEntry != null) {
-      overlayState.insert(_overlayEntry!);
+      overlayState?.insert(_overlayEntry!);
     }
 
     // Add timeout for the tooltip to disapear after a few seconds


### PR DESCRIPTION
- The "insert" method cannot be called on a null value, so it is recommended to use "?." operator instead of "." to handle the null case.

```
: Error: Method 'insert' cannot be called on 'OverlayState?' because it is potentially null.
../…/lib/el_tooltip.dart:134
- 'OverlayState' is from 'package:flutter/src/widgets/overlay.dart' ('../../fvm/versions/stable/packages/flutter/lib/src/widgets/overlay.dart').
package:flutter/…/widgets/overlay.dart:1
Try calling using ?. instead.
      overlayStateHidden.insert(_overlayEntryHidden!);
                         ^^^^^^
: Error: Method 'insert' cannot be called on 'OverlayState?' because it is potentially null.
../…/lib/el_tooltip.dart:228
- 'OverlayState' is from 'package:flutter/src/widgets/overlay.dart' ('../../fvm/versions/stable/packages/flutter/lib/src/widgets/overlay.dart').
package:flutter/…/widgets/overlay.dart:1

Try calling using ?. instead.
      overlayState.insert(_overlayEntry!);
                   ^^^^^^
```