### PR TITLE
Try disappearing Tooltip and Cleanup Overlay after being disposed

### DIFF
--- a/lib/el_tooltip.dart
+++ b/lib/el_tooltip.dart
@@ -120,6 +120,8 @@ class _ElTooltipState extends State<ElTooltip> with WidgetsBindingObserver {
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    // remove the overlay after hiding it
+    _hideOverlay().then((_) => _overlayEntryHidden?.remove());
     super.dispose();
   }
 

--- a/lib/el_tooltip.dart
+++ b/lib/el_tooltip.dart
@@ -105,11 +105,15 @@ class _ElTooltipState extends State<ElTooltip> with WidgetsBindingObserver {
 
   final GlobalKey _widgetKey = GlobalKey();
 
+  bool initial = true;
+
   /// Automatically hide the overlay when the screen dimension changes
   /// or when the user scrolls. This is done to avoid displacement.
   @override
   void didChangeMetrics() {
-    _hideOverlay();
+    // do not hide the overlay if it's the first time it's shown
+    if (!initial) _hideOverlay();
+    setState(() => initial = false);
   }
 
   /// Dispose the observer
@@ -203,6 +207,9 @@ class _ElTooltipState extends State<ElTooltip> with WidgetsBindingObserver {
 
   /// Loads the tooltip into view
   Future<void> _showOverlay([BuildContext? context]) async {
+    // fix for disappearing tooltip
+    setState(() => initial = true);
+
     context ??= this.context;
     final overlayState = Overlay.of(context);
 


### PR DESCRIPTION
After debugging the show and hide methods, I can see, that the hide method is called immediately after show, hiding the tooltip when trying to show it via the controller while `showModal` is true. 

It's triggered by the `didChangeMetrics` calling `_hideOverlay()` on the `_ElTooltipState`.  To prevent this from happening when the tooltip appears, I introduced a `initial` state which only allows hiding based on metrics changes, after the first instance. Maybe there is a more elegant solution, but it works so far.


So did I struggle a bit with an issue, where the screen got blocked over time and I couldn't tap on the content in the middle of the screen. After some investigation I found out, that El_Tooltip did not clean up the content inside the Overlay region after being disposed, resulting in tappable but invisible text nodes flying around the app after navigation.


You can try my fix like this:

```yaml
el_tooltip:
    git:
      url: https://github.com/appinteractive/el_tooltip
      ref: 62fdea1437e923e0561a4dd7c4e6e73aabeddfdb
```