### PR TITLE
add the rootOverlay parameter to support navigation nesting.

### DIFF
--- a/example/lib/main_sub.dart
+++ b/example/lib/main_sub.dart
@@ -1,0 +1,118 @@
+import 'package:el_tooltip/el_tooltip.dart';
+import 'package:flutter/material.dart';
+
+///
+/// @author <a href="mailto:angcyo@126.com">angcyo</a>
+/// @date 2025/01/02
+///
+
+void main() {
+  const tooltipContent = Text(
+    'Hola Mundo!',
+    style: TextStyle(color: Colors.white),
+    textAlign: TextAlign.center,
+  );
+
+  const tooltipIcon = Icon(
+    Icons.info,
+    color: Color(0XFFA5A53A),
+  );
+
+  runApp(
+    MaterialApp(
+      title: 'ElTooltip Sub Navigator Demo',
+      theme: ThemeData(
+        appBarTheme: const AppBarTheme(color: Color(0XFFA5A53A)),
+        scaffoldBackgroundColor: const Color(0XFFFFF8C7),
+      ),
+      home: Scaffold(
+        appBar: AppBar(title: const Text('ElTooltip Sub Navigator Demo')),
+        body: SafeArea(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const SizedBox(
+                height: 80,
+              ),
+              Expanded(
+                  child: Navigator(
+                onDidRemovePage: (page) {},
+                pages: const [
+                  MaterialPage(
+                      child: Column(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Row(
+                        children: [
+                          ElTooltip(
+                            content: tooltipContent,
+                            color: Color(0XFFEA4747),
+                            child: tooltipIcon,
+                          ),
+                          Spacer(),
+                          ElTooltip(
+                            content: tooltipContent,
+                            color: Color(0XFFEA4747),
+                            child: tooltipIcon,
+                          ),
+                          Spacer(),
+                          ElTooltip(
+                            content: tooltipContent,
+                            color: Color(0XFFEA4747),
+                            child: tooltipIcon,
+                          ),
+                        ],
+                      ),
+                      Row(
+                        children: [
+                          ElTooltip(
+                            content: tooltipContent,
+                            color: Color(0XFFEA4747),
+                            child: tooltipIcon,
+                          ),
+                          Spacer(),
+                          ElTooltip(
+                            content: tooltipContent,
+                            color: Color(0XFFEA4747),
+                            child: tooltipIcon,
+                          ),
+                          Spacer(),
+                          ElTooltip(
+                            content: tooltipContent,
+                            color: Color(0XFFEA4747),
+                            child: tooltipIcon,
+                          ),
+                        ],
+                      ),
+                      Row(
+                        children: [
+                          ElTooltip(
+                            content: tooltipContent,
+                            color: Color(0XFFEA4747),
+                            child: tooltipIcon,
+                          ),
+                          Spacer(),
+                          ElTooltip(
+                            content: tooltipContent,
+                            color: Color(0XFFEA4747),
+                            child: tooltipIcon,
+                          ),
+                          Spacer(),
+                          ElTooltip(
+                            content: tooltipContent,
+                            color: Color(0XFFEA4747),
+                            child: tooltipIcon,
+                          ),
+                        ],
+                      ),
+                    ],
+                  ))
+                ],
+              )),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/example/lib/main_sub.dart
+++ b/example/lib/main_sub.dart
@@ -37,7 +37,7 @@ void main() {
               Expanded(
                   child: Navigator(
                 onDidRemovePage: (page) {},
-                pages: const [
+                pages: [
                   MaterialPage(
                       child: Column(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -46,24 +46,55 @@ void main() {
                         children: [
                           ElTooltip(
                             content: tooltipContent,
-                            color: Color(0XFFEA4747),
+                            color: const Color(0XFFEA4747),
+                            showModal: false,
                             child: tooltipIcon,
+                            arrowWrapBuilder: (context, child) {
+                              return Container(
+                                decoration: const BoxDecoration(
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: Colors.black12,
+                                      offset: Offset(0, 2),
+                                      blurRadius: 5,
+                                      spreadRadius: 0,
+                                    ),
+                                  ],
+                                ),
+                                child: child!,
+                              );
+                            },
+                            contentWrapBuilder: (context, child) {
+                              return Container(
+                                decoration: const BoxDecoration(
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: Colors.black26,
+                                      offset: Offset(1, 2),
+                                      blurRadius: 5,
+                                      spreadRadius: 2,
+                                    ),
+                                  ],
+                                ),
+                                child: child!,
+                              );
+                            },
                           ),
-                          Spacer(),
-                          ElTooltip(
+                          const Spacer(),
+                          const ElTooltip(
                             content: tooltipContent,
                             color: Color(0XFFEA4747),
                             child: tooltipIcon,
                           ),
-                          Spacer(),
-                          ElTooltip(
+                          const Spacer(),
+                          const ElTooltip(
                             content: tooltipContent,
                             color: Color(0XFFEA4747),
                             child: tooltipIcon,
                           ),
                         ],
                       ),
-                      Row(
+                      const Row(
                         children: [
                           ElTooltip(
                             content: tooltipContent,
@@ -84,7 +115,7 @@ void main() {
                           ),
                         ],
                       ),
-                      Row(
+                      const Row(
                         children: [
                           ElTooltip(
                             content: tooltipContent,

--- a/lib/el_tooltip.dart
+++ b/lib/el_tooltip.dart
@@ -38,6 +38,8 @@ class ElTooltip extends StatefulWidget {
     this.appearAnimationDuration = Duration.zero,
     this.disappearAnimationDuration = Duration.zero,
     this.controller,
+    this.arrowWrapBuilder,
+    this.contentWrapBuilder,
     super.key,
   });
 
@@ -93,6 +95,12 @@ class ElTooltip extends StatefulWidget {
 
   /// [controller] Controller that allows to show or hide the tooltip
   final ElTooltipController? controller;
+
+  /// [arrowWrapBuilder] Builder that wraps the arrow
+  final TransitionBuilder? arrowWrapBuilder;
+
+  /// [contentWrapBuilder] Builder that wraps the content
+  final TransitionBuilder? contentWrapBuilder;
 
   @override
   State<ElTooltip> createState() => _ElTooltipState();
@@ -247,6 +255,8 @@ class _ElTooltipState extends State<ElTooltip> with WidgetsBindingObserver {
         showModal: widget.showModal,
         appearAnimationDuration: widget.appearAnimationDuration,
         disappearAnimationDuration: widget.disappearAnimationDuration,
+        arrowWrapBuilder: widget.arrowWrapBuilder,
+        contentWrapBuilder: widget.contentWrapBuilder,
         child: widget.child,
       ),
     );

--- a/lib/el_tooltip.dart
+++ b/lib/el_tooltip.dart
@@ -32,6 +32,7 @@ class ElTooltip extends StatefulWidget {
     this.showModal = true,
     this.showArrow = true,
     this.showChildAboveOverlay = true,
+    this.rootOverlay = true,
     this.modalConfiguration = const ModalConfiguration(),
     this.timeout = Duration.zero,
     this.appearAnimationDuration = Duration.zero,
@@ -70,6 +71,9 @@ class ElTooltip extends StatefulWidget {
 
   /// [showChildAboveOverlay] Shows the child above the overlay.
   final bool showChildAboveOverlay;
+
+  /// [rootOverlay] If true, the overlay will be added to the root overlay.
+  final bool rootOverlay;
 
   /// [timeout] Timeout until the tooltip disappears automatically
   /// The default value is 0 (zero) which means it never disappears.
@@ -154,7 +158,7 @@ class _ElTooltipState extends State<ElTooltip> with WidgetsBindingObserver {
 
   /// Loads the tooltip without opacity to measure the rendered size
   void _loadHiddenOverlay(_) {
-    OverlayState? overlayStateHidden = Overlay.of(context);
+    OverlayState? overlayStateHidden = Overlay.of(context, rootOverlay: widget.rootOverlay);
     _overlayEntryHidden = OverlayEntry(
       builder: (context) {
         WidgetsBinding.instance
@@ -212,7 +216,7 @@ class _ElTooltipState extends State<ElTooltip> with WidgetsBindingObserver {
     setState(() => initial = true);
 
     context ??= this.context;
-    final overlayState = Overlay.of(context);
+    final overlayState = Overlay.of(context, rootOverlay: widget.rootOverlay);
 
     /// By calling [PositionManager.load()] we get returned the position
     /// of the tooltip, the arrow and the trigger.

--- a/lib/el_tooltip.dart
+++ b/lib/el_tooltip.dart
@@ -146,6 +146,12 @@ class _ElTooltipState extends State<ElTooltip> with WidgetsBindingObserver {
     widget.controller?.attach(show: _showOverlay, hide: _hideOverlay);
   }
 
+  @override
+  void didUpdateWidget(covariant ElTooltip oldWidget) {
+    widget.controller?.attach(show: _showOverlay, hide: _hideOverlay);
+    super.didUpdateWidget(oldWidget);
+  }
+
   ElementBox get _screenSize => _getScreenSize();
 
   ElementBox get _triggerBox => _getTriggerSize();

--- a/lib/src/bubble.dart
+++ b/lib/src/bubble.dart
@@ -10,6 +10,8 @@ class Bubble extends StatefulWidget {
   final ElementBox triggerBox;
   final BorderRadiusGeometry? radius;
   final Widget child;
+  /// [contentWrapBuilder] Builder that wraps the content
+  final TransitionBuilder? contentWrapBuilder;
 
   const Bubble({
     this.color = Colors.white,
@@ -18,6 +20,7 @@ class Bubble extends StatefulWidget {
     required this.child,
     required this.triggerBox,
     this.maxWidth = 300.0,
+    this.contentWrapBuilder,
     super.key,
   });
 
@@ -28,19 +31,23 @@ class Bubble extends StatefulWidget {
 class _BubbleState extends State<Bubble> {
   @override
   Widget build(BuildContext context) {
+    Widget content = Container(
+      constraints: BoxConstraints(maxWidth: widget.maxWidth),
+      decoration: BoxDecoration(
+        borderRadius: widget.radius,
+        color: widget.color,
+      ),
+      padding: widget.padding,
+      child: widget.child,
+    );
+    if (widget.contentWrapBuilder != null) {
+      content = widget.contentWrapBuilder!(context, content);
+    }
     return Material(
       color: Colors.transparent,
       child: Opacity(
         opacity: 1.0,
-        child: Container(
-          constraints: BoxConstraints(maxWidth: widget.maxWidth),
-          decoration: BoxDecoration(
-            borderRadius: widget.radius,
-            color: widget.color,
-          ),
-          padding: widget.padding,
-          child: widget.child,
-        ),
+        child: content,
       ),
     );
   }

--- a/lib/src/el_tooltip_overlay.dart
+++ b/lib/src/el_tooltip_overlay.dart
@@ -23,6 +23,8 @@ class ElTooltipOverlay extends StatefulWidget {
     required this.arrowBox,
     required this.appearAnimationDuration,
     required this.disappearAnimationDuration,
+    this.arrowWrapBuilder,
+    this.contentWrapBuilder,
   });
 
   /// [child] Widget that will trigger the tooltip to appear.
@@ -70,6 +72,12 @@ class ElTooltipOverlay extends StatefulWidget {
   /// The default value is 0 which means it doesn't animate
   final Duration disappearAnimationDuration;
 
+  /// [arrowWrapBuilder] Builder that wraps the arrow
+  final TransitionBuilder? arrowWrapBuilder;
+
+  /// [contentWrapBuilder] Builder that wraps the content
+  final TransitionBuilder? contentWrapBuilder;
+
   @override
   State<ElTooltipOverlay> createState() => ElTooltipOverlayState();
 }
@@ -102,6 +110,15 @@ class ElTooltipOverlayState extends State<ElTooltipOverlay> {
 
   @override
   Widget build(BuildContext context) {
+    Widget arrow = Arrow(
+      color: widget.color,
+      position: widget.toolTipElementsDisplay.position,
+      width: widget.arrowBox.w,
+      height: widget.arrowBox.h,
+    );
+    if (widget.arrowWrapBuilder != null) {
+      arrow = widget.arrowWrapBuilder!(context, arrow);
+    }
     return AnimatedOpacity(
       opacity: opacity,
       duration: closing
@@ -123,6 +140,7 @@ class ElTooltipOverlayState extends State<ElTooltipOverlay> {
               padding: widget.padding,
               radius: widget.toolTipElementsDisplay.radius,
               color: widget.color,
+              contentWrapBuilder: widget.contentWrapBuilder,
               child: widget.content,
             ),
           ),
@@ -130,12 +148,7 @@ class ElTooltipOverlayState extends State<ElTooltipOverlay> {
             Positioned(
               top: widget.toolTipElementsDisplay.arrow.y,
               left: widget.toolTipElementsDisplay.arrow.x,
-              child: Arrow(
-                color: widget.color,
-                position: widget.toolTipElementsDisplay.position,
-                width: widget.arrowBox.w,
-                height: widget.arrowBox.h,
-              ),
+              child: arrow,
             ),
           if (widget.showChildAboveOverlay)
             Positioned(


### PR DESCRIPTION
If the navigation is nested, el_tooltip will not work properly.

> example:
https://raw.githubusercontent.com/FlutterStudioIst/el_tooltip/refs/heads/main/example/lib/main_sub.dart